### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan payments

### DIFF
--- a/payments/README.md
+++ b/payments/README.md
@@ -7,8 +7,6 @@
 
 <!-- Start Dev Containers -->
 
-
-
 <!-- End Dev Containers -->
 
 <!-- Placeholder for Future Speakeasy SDK Sections -->

--- a/payments/RELEASES.md
+++ b/payments/RELEASES.md
@@ -16,6 +16,6 @@ Based on:
 - OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
 - Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
 ### Generated
-- [csharp v0.2.0] payments
+- [csharp v1.0.0] payments
 ### Releases
-- [NuGet v0.2.0] https://www.nuget.org/packages/openapi/0.2.0 - payments
+- [NuGet v1.0.0] https://www.nuget.org/packages/WingspanPayments/1.0.0 - payments

--- a/payments/RELEASES.md
+++ b/payments/RELEASES.md
@@ -9,3 +9,13 @@ Based on:
 - [csharp v0.1.0] payments
 ### Releases
 - [NuGet v0.1.0] https://www.nuget.org/packages/openapi/0.1.0 - payments
+
+## 2023-10-30 14:46:08
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
+- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [csharp v0.2.0] payments
+### Releases
+- [NuGet v0.2.0] https://www.nuget.org/packages/openapi/0.2.0 - payments

--- a/payments/SDK/SDK.csproj
+++ b/payments/SDK/SDK.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <PackageId>openapi</PackageId>
-    <Version>0.2.0</Version>
+    <PackageId>WingspanPayments</PackageId>
+    <Version>1.0.0</Version>
     <Authors>Speakeasy</Authors>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/payments/SDK/SDK.csproj
+++ b/payments/SDK/SDK.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>openapi</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Speakeasy</Authors>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/payments/SDK/SDKSDK.cs
+++ b/payments/SDK/SDKSDK.cs
@@ -81,10 +81,10 @@ namespace SDK
         };
 
         private const string _language = "csharp";
-        private const string _sdkVersion = "0.1.0";
-        private const string _sdkGenVersion = "2.171.0";
+        private const string _sdkVersion = "0.2.0";
+        private const string _sdkGenVersion = "2.173.0";
         private const string _openapiDocVersion = "1.0.0";
-        private const string _userAgent = "speakeasy-sdk/csharp 0.1.0 2.171.0 1.0.0 openapi";
+        private const string _userAgent = "speakeasy-sdk/csharp 0.2.0 2.173.0 1.0.0 openapi";
         private string _serverUrl = "";
         private ISpeakeasyHttpClient _defaultClient;
         private ISpeakeasyHttpClient _securityClient;

--- a/payments/SDK/SDKSDK.cs
+++ b/payments/SDK/SDKSDK.cs
@@ -81,10 +81,10 @@ namespace SDK
         };
 
         private const string _language = "csharp";
-        private const string _sdkVersion = "0.2.0";
+        private const string _sdkVersion = "1.0.0";
         private const string _sdkGenVersion = "2.173.0";
         private const string _openapiDocVersion = "1.0.0";
-        private const string _userAgent = "speakeasy-sdk/csharp 0.2.0 2.173.0 1.0.0 openapi";
+        private const string _userAgent = "speakeasy-sdk/csharp 1.0.0 2.173.0 1.0.0 WingspanPayments";
         private string _serverUrl = "";
         private ISpeakeasyHttpClient _defaultClient;
         private ISpeakeasyHttpClient _securityClient;

--- a/payments/gen.yaml
+++ b/payments/gen.yaml
@@ -2,8 +2,8 @@ configVersion: 1.0.0
 management:
   docChecksum: e377727f5ba4f1205fcadb3246757bab
   docVersion: 1.0.0
-  speakeasyVersion: 1.107.0
-  generationVersion: 2.171.0
+  speakeasyVersion: 1.109.0
+  generationVersion: 2.173.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-csharp.git
   sdkClassName: SDK
@@ -14,7 +14,7 @@ features:
     flattening: 2.81.1
     globalServerURLs: 2.82.0
 csharp:
-  version: 0.1.0
+  version: 0.2.0
   author: Speakeasy
   dotnetVersion: net5.0
   maxMethodParams: 4

--- a/payments/gen.yaml
+++ b/payments/gen.yaml
@@ -14,10 +14,10 @@ features:
     flattening: 2.81.1
     globalServerURLs: 2.82.0
 csharp:
-  version: 0.2.0
-  author: Speakeasy
+  version: 1.0.0
+  author: Wingspan Networks, Inc.
   dotnetVersion: net5.0
   maxMethodParams: 4
-  packageName: openapi
+  packageName: WingspanPayments
   published: true
   repoSubDirectory: payments


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy


## CSHARP CHANGELOG


